### PR TITLE
Add parser to decompose (large) files

### DIFF
--- a/gpt_migrate/config.py
+++ b/gpt_migrate/config.py
@@ -74,6 +74,30 @@ INCLUDED_EXTENSIONS = (
     # TODO: add more
 )
 
+TREE_SITTER_REPO_STUB = "https://github.com/tree-sitter/tree-sitter-"
+
+EXTENSION_TO_TREE_SITTER_GRAMMAR_REPO = {
+    'py': TREE_SITTER_REPO_STUB + "python",
+    'js': TREE_SITTER_REPO_STUB + "javascript",
+    'java': TREE_SITTER_REPO_STUB + "java",
+    'rb': TREE_SITTER_REPO_STUB + "ruby",
+    'php': TREE_SITTER_REPO_STUB + "php",
+    'cs': TREE_SITTER_REPO_STUB + "c-sharp",
+    'go': TREE_SITTER_REPO_STUB + "go",
+    'rs': TREE_SITTER_REPO_STUB + "rust",
+    'cpp': TREE_SITTER_REPO_STUB + "cpp",
+    'cc': TREE_SITTER_REPO_STUB + "cpp",
+    'cxx': TREE_SITTER_REPO_STUB + "cpp",
+    'c': TREE_SITTER_REPO_STUB + "c",
+    'swift': TREE_SITTER_REPO_STUB + "swift",
+    'scala': TREE_SITTER_REPO_STUB + "scala",
+    'ts': TREE_SITTER_REPO_STUB + "typescript",
+    'tsx': TREE_SITTER_REPO_STUB + "typescript",
+    'jsx': TREE_SITTER_REPO_STUB + "javascript",
+    'hs': TREE_SITTER_REPO_STUB + "haskell",
+    'jl': TREE_SITTER_REPO_STUB + "julia",
+}
+
 EXTENSION_TO_LANGUAGE = {
     'py': 'Python',
     'js': 'JavaScript',
@@ -107,5 +131,4 @@ EXTENSION_TO_LANGUAGE = {
     'hs': 'Haskell',
     'jl': 'Julia',
     'nim': 'Nim',
-    'php': 'PHP',
 }

--- a/gpt_migrate/parser.py
+++ b/gpt_migrate/parser.py
@@ -1,0 +1,47 @@
+import subprocess
+import typer
+from yaspin import yaspin
+from pathlib import Path
+from tree_sitter import Language, Parser
+
+from config import EXTENSION_TO_TREE_SITTER_GRAMMAR_REPO, EXTENSION_TO_LANGUAGE
+
+def decompose_file(file_path: str):
+    # Do a first-level parse tree decomposition of the file at file_path
+    with yaspin(text="Decomposing file", spinner="dots") as spinner:
+        repo_url = EXTENSION_TO_TREE_SITTER_GRAMMAR_REPO.get(file_path.split('.')[-1])
+
+        if not repo_url:
+            success_text = typer.style("Couldn't find tree-sitter grammar for programming language {}. Aborting decomposition of file.".format(EXTENSION_TO_LANGUAGE.get(file_path.split('.')[-1])), fg=typer.colors.RED)
+            typer.echo(success_text)
+
+        repo_name = repo_url.split('/')[-1]
+        if not Path("cache/tree-sitter/" + repo_name).exists():
+            Path("cache/tree-sitter").mkdir(parents=True, exist_ok=True)
+            result = subprocess.run(["git", "clone", repo_url], cwd="cache/tree-sitter", stdout=subprocess.PIPE, stderr=subprocess.STDOUT, check=True, text=True)
+
+        grammar_lib_path = Path("cache/tree-sitter/my-languages.so")
+        if grammar_lib_path.exists():
+            grammar_lib_path.unlink()
+
+        Language.build_library(
+            'cache/tree-sitter/my-languages.so',
+            ['cache/tree-sitter/' + repo_name]
+        )
+
+        lang = Language('cache/tree-sitter/my-languages.so', repo_url.split('-')[-1])
+        parser = Parser()
+        parser.set_language(lang)
+
+        with open(file_path) as f:
+            source_code = f.read()  
+
+        tree = parser.parse(bytes(source_code, "utf8"))
+
+        root_node = tree.root_node
+
+        for child in root_node.children:
+            yield child
+        
+        spinner.ok("✅ ")
+

--- a/gpt_migrate/parser.py
+++ b/gpt_migrate/parser.py
@@ -2,11 +2,12 @@ import subprocess
 import typer
 from yaspin import yaspin
 from pathlib import Path
-from tree_sitter import Language, Parser
+from tree_sitter import Language, Parser, Node
+from collections.abc import Iterator
 
 from config import EXTENSION_TO_TREE_SITTER_GRAMMAR_REPO, EXTENSION_TO_LANGUAGE
 
-def decompose_file(file_path: str):
+def decompose_file(file_path: str) -> Iterator[Node]:
     # Do a first-level parse tree decomposition of the file at file_path
     with yaspin(text="Decomposing file", spinner="dots") as spinner:
         repo_url = EXTENSION_TO_TREE_SITTER_GRAMMAR_REPO.get(file_path.split('.')[-1])

--- a/gpt_migrate/requirements.txt
+++ b/gpt_migrate/requirements.txt
@@ -2,3 +2,4 @@ typer
 langchain
 yaspin
 openai
+tree_sitter


### PR DESCRIPTION
This PR adds a module to decompose a file into their first-level parse tree units i.e. functions, classes etc.. The decomposed can be accessed over the `text` property of the `Node` object. It uses [tree-sitter](https://github.com/tree-sitter/tree-sitter) that already comes with grammars for a wide range of languages (see diff in config.py). Tree-sitter seems like a mature project and is used for [syntax highlighting on github.com](https://tree-sitter.github.io/tree-sitter/syntax-highlighting). 

I think using a parser for decomposition has several advantages:
- Decomposing a file into logical units is superior to naive chunking for downstream migration tasks
- Having a parse tree opens up other downstream applications such as in-file dependency resolve or function extraction
- Using an LLM to decompose large files 
  - requires naive chunking as preprocessing
  - is slower, more costly and potentially inaccurate